### PR TITLE
Split Copy action

### DIFF
--- a/checkpoint_schedules/mixed.py
+++ b/checkpoint_schedules/mixed.py
@@ -1,5 +1,5 @@
 import warnings
-from .schedule import CheckpointSchedule, Forward, Reverse, Copy,\
+from .schedule import CheckpointSchedule, Forward, Reverse, Copy, Move,\
     EndForward, EndReverse, StorageType, StepType
 
 from .utils import mixed_step_memoization, mixed_step_memoization_0,\
@@ -90,7 +90,7 @@ class MixedCheckpointSchedule(CheckpointSchedule):
                     elif n1 <= n0:
                         raise InvalidForwardStep
                     self._n += 1
-                    yield Forward(n1 - 1, n1, False, True, StorageType.TAPE)
+                    yield Forward(n1 - 1, n1, False, True, StorageType.WORK)
                 elif step_type == StepType.FORWARD:
                     if n1 <= n0:
                         raise InvalidForwardStep
@@ -155,7 +155,9 @@ class MixedCheckpointSchedule(CheckpointSchedule):
                 self._n += 1
             elif step_type != StepType.READ_ICS:
                 raise RuntimeError("Invalid checkpointing state")
-            yield Copy(cp_n, self._storage, StorageType.TAPE, delete=cp_delete)
+            yield Copy(cp_n, self._storage, StorageType.WORK)
+            if cp_delete:
+                yield Move(cp_n, self._storage, StorageType.NONE)
 
         if len(snapshot_n) > 0 or len(snapshots) > 0:
             raise RuntimeError("Invalid checkpointing state")

--- a/checkpoint_schedules/none_revolver.py
+++ b/checkpoint_schedules/none_revolver.py
@@ -20,7 +20,7 @@ class SingleStorageSchedule(CheckpointSchedule):
     Online, unlimited adjoint calculations permitted.
     """
 
-    def __init__(self, storage=StorageType.RAM):
+    def __init__(self, storage=StorageType.WORK):
         self._storage = storage
         super().__init__()
     

--- a/checkpoint_schedules/schedule.py
+++ b/checkpoint_schedules/schedule.py
@@ -11,6 +11,7 @@ __all__ = \
         "Forward",
         "Reverse",
         "Copy",
+        "Move",
         "EndForward",
         "EndReverse",
         "CheckpointSchedule",
@@ -19,16 +20,18 @@ __all__ = \
 
 class StorageType(Enum):
     """
-    RAM : It is the first level of checkpoint storage.
+    RAM : It is the first type of checkpoint storage.
 
-    DISK : It is the second level of checkpoint storage.
+    DISK : It is the second type of checkpoint storage.
+    
+    WORK : ...
 
     NONE : Indicate that there is no specific storage location defined 
     for the checkpoint data.
     """
     RAM = 0
     DISK = 1
-    TAPE = -1
+    WORK = -1
     NONE = None
 
 
@@ -86,7 +89,7 @@ class Forward(CheckpointAction):
         Indicate whether to store the checkpont data used in 
         the reverse computation.
     storage : str
-        Indicate the level to store the checkpoint data, which can be either `RAM` or `DISK`.
+        Indicate the type to store the checkpoint data, which can be either `RAM` or `DISK`.
 
     
     Notes
@@ -243,7 +246,8 @@ class Reverse(CheckpointAction):
 
 
 class Copy(CheckpointAction):
-    """Indicate the action of copying from a storage level. 
+    """Indicate the action of copying from a storage type
+    to another storage type. 
 
     
     Attributes
@@ -251,30 +255,26 @@ class Copy(CheckpointAction):
     n : int
         The step with which the copied data is associated.
     from_storage : str
-        The storage level from which the data should be copied. Either
+        The storage type from which the data should be copied. Either
         `StorageLocation.RAM.name` or `StorageLocation.DISK.name`. 
     to_storage : str
         The location to which the data should be copied, which is 
-        referred to as `StorageLocation.TAPE.name`.
-    delete : bool
-        Whether the data should be deleted from the indicated storage level
-        after it has been copied.
+        referred to as `StorageLocation.WORK`.
 
     Notes
     -----
-        `StorageLocation.TAPE.name` refers to the local storage that 
+        `StorageLocation.WORK` refers to the local storage that 
         holds the checkpoint data used as the initial condition 
-        for the forward solver. It is not considered a storage level since is
-        specifically designated for storing this particular type of checkpoint data.
-        The storage location are listed in the `StorageLocation`.
+        for the forward solver.The storage location are listed in the 
+        `StorageLocation`.
     
     See Also
     --------
     :class:`StorageLocation` 
 
     """
-    def __init__(self, n, from_storage, to_storage, delete=False):
-        super().__init__(n, from_storage, to_storage, delete)
+    def __init__(self, n, from_storage, to_storage):
+        super().__init__(n, from_storage, to_storage)
 
     @property
     def n(self):
@@ -289,7 +289,7 @@ class Copy(CheckpointAction):
     
     @property
     def from_storage(self):
-        """The storage level to copy the checkpoint data.
+        """The storage type to copy the checkpoint data.
 
         Notes
         -----
@@ -310,31 +310,71 @@ class Copy(CheckpointAction):
     
     @property
     def to_storage(self):
-        """The tape used to restart the foward solver.
+        """The ....
 
         Returns
         -------
         str
-            The `TAPE`.
+            The `WORK`.
         """
         return self.args[2]
-    
-    @property
-    def delete(self):
-        """Delete the checkpoint stored in a storage level. 
-        
 
-        Notes
-        -----
-        The storage level is given by `from_storage` property.
+
+class Move(CheckpointAction):
+    """Indicate the action of moving from a storage type
+    to another storage type. 
+
+    
+    Attributes
+    ----------
+    n : int
+        The step with which the copied data is associated.
+    from_storage : ...
+        The storage type from which the data should be copied. Either
+        `StorageLocation.RAM` or `StorageLocation.DISK`. 
+    to_storage : ...
+        ...
+    
+    See Also
+    --------
+    :class:`StorageLocation` 
+
+    """
+    def __init__(self, n, from_storage, to_storage):
+        super().__init__(n, from_storage, to_storage)
+
+    @property
+    def n(self):
+        """The step to copy the forward checkpoint data.
 
         Returns
         -------
-        bool
-            Delete the checkpoint data if ``True``.
+        int
+            The copy step.
         """
-        return self.args[3]
+        return self.args[0]
+    
+    @property
+    def from_storage(self):
+        """The storage type to copy the checkpoint data.
 
+        Notes
+        -----
+        Storage location are available in `StorageLocation`.
+
+        
+        Returns
+        -------
+        str
+            Either `RAM` or `DISK`.
+        """
+        return self.args[1]
+    
+    @property
+    def to_storage(self):
+
+        return self.args[2]
+    
 
 
 

--- a/checkpoint_schedules/twolevel_binomial.py
+++ b/checkpoint_schedules/twolevel_binomial.py
@@ -1,4 +1,4 @@
-from .schedule import CheckpointSchedule, Forward, Reverse, Copy,\
+from .schedule import CheckpointSchedule, Forward, Reverse, Copy, Move,\
     EndForward, EndReverse, StorageType
 from .utils import n_advance
 
@@ -83,15 +83,16 @@ class TwoLevelCheckpointSchedule(CheckpointSchedule):
                         snapshots.pop()
                         self._n = cp_n
                         if cp_n == n0s:
-                            yield Copy(cp_n, StorageType.DISK, StorageType.TAPE, delete=False)
+                            yield Copy(cp_n, StorageType.DISK, StorageType.WORK)
                         else:
-                            yield Copy(cp_n, self._binomial_storage, StorageType.TAPE, delete=True)
+                            yield Copy(cp_n, self._binomial_storage, StorageType.WORK)
+                            yield Move(cp_n, self._binomial_storage, StorageType.NONE)
                     else:
                         self._n = cp_n
                         if cp_n == n0s:
-                            yield Copy(cp_n, StorageType.DISK, StorageType.TAPE, delete=False)
+                            yield Copy(cp_n, StorageType.DISK, StorageType.WORK)
                         else:
-                            yield Copy(cp_n, self._binomial_storage, StorageType.TAPE, delete=False)
+                            yield Copy(cp_n, self._binomial_storage, StorageType.WORK)
 
                         n_snapshots = (self._binomial_snapshots + 1
                                        - len(snapshots) + 1)
@@ -123,7 +124,7 @@ class TwoLevelCheckpointSchedule(CheckpointSchedule):
                             raise RuntimeError("Invalid checkpointing state")
 
                     self._n += 1
-                    yield Forward(self._n - 1, self._n, False, True, StorageType.TAPE)
+                    yield Forward(self._n - 1, self._n, False, True, StorageType.WORK)
 
                     self._r += 1
                     yield Reverse(self._n, self._n - 1, True)

--- a/tests/test_multistage.py
+++ b/tests/test_multistage.py
@@ -131,12 +131,7 @@ def test_multistage(trajectory,
         assert cp_action.from_storage == StorageType.DISK
         cp = snapshots[cp_action.n]
 
-        # The checkpoint contains forward restart data
-        assert len(cp[0]) > 0
-        assert len(cp[1]) == 0
-
-        # The loaded data is deleted if it is exactly one step away from the
-        # current location of the adjoint
+        assert len(cp[0]) > 0 or len(cp[1]) > 0
 
         if cp_action.to_storage == StorageType.NONE:
             assert (cp_action.n == n - model_r - 1)

--- a/tests/test_validity.py
+++ b/tests/test_validity.py
@@ -28,20 +28,6 @@ from checkpoint_schedules import HRevolve, DiskRevolve, PeriodicDiskRevolve,\
 
 
 def h_revolve(n, s):
-    """H-revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to store in RAM.
-
-    Returns
-    -------
-    (HRevolve, dict, int)
-        H-revolver, checkpoint storage limits, data limit.
-    """
     snap_ram = s//3
     snap_disk = s - s//3
     if s//3 < 1:
@@ -55,20 +41,6 @@ def h_revolve(n, s):
 
 
 def disk_revolve(n, s):
-    """Disk revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to store in RAM.
-
-    Returns
-    -------
-    (DiskRevolve, dict, int)
-        Disk revolver, checkpoint storage limits, data limit.
-    """
     if s < 1:
         return (None,
                 {StorageType.RAM: 0, StorageType.DISK: 0}, 0)
@@ -79,64 +51,16 @@ def disk_revolve(n, s):
 
 
 def multistage(n, s):
-    """Disk revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to store in RAM.
-
-    Returns
-    -------
-    (DiskRevolve, dict, int)
-        Disk revolver, checkpoint storage limits, data limit.
-    """
-    if s < 1:
-        return (None,
-                {StorageType.RAM: 0, StorageType.DISK: 0}, 0)
-    else:
-        revolver = MultistageCheckpointSchedule(n, s//3, s - s//3)
-        return (revolver,
-                {StorageType.RAM: s//3, StorageType.DISK: s - s//3}, 1)
+    return (MultistageCheckpointSchedule(n, 0, s),
+            {StorageType.RAM: 0, StorageType.DISK: s}, 1)
 
 
 def twolevel_binomial(n, s):
-    """Disk revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to store in RAM.
-
-    Returns
-    -------
-    (DiskRevolve, dict, int)
-        Disk revolver, checkpoint storage limits, data limit.
-    """
-
     return (TwoLevelCheckpointSchedule(2, s, binomial_storage=StorageType.RAM),
             {StorageType.RAM: s, StorageType.DISK: 1 + (n - 1) // 2}, 1)
 
 
 def periodic_disk(n, s):
-    """Periodic disk revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to save in RAM.
-
-    Returns
-    -------
-    (PeriodicDiskRevolve, dict, int)
-        Periodic disk revolver, checkpoint storage limits, data limit.
-    """
     if s < 1:
         return (None,
                 {StorageType.RAM: 0, StorageType.DISK: 0}, 0)
@@ -148,20 +72,6 @@ def periodic_disk(n, s):
 
 
 def revolve(n, s):
-    """Periodic disk revolver.
-
-    Parameters
-    ----------
-    n : int
-        Total forward steps.
-    s : int
-        Snapshots to save in RAM.
-
-    Returns
-    -------
-    (PeriodicDiskRevolve, dict, int)
-        Periodic disk revolver, checkpoint storage limits, data limit.
-    """
     if s < 1:
         return (None,
                 {StorageType.RAM: 0, StorageType.DISK: 0}, 0)
@@ -179,13 +89,13 @@ def mixed(n, s):
 @pytest.mark.parametrize(
     "schedule",
     [
-    #  revolve,
-    #  periodic_disk,
-    #  disk_revolve,
-    #  h_revolve,
+     revolve,
+     periodic_disk,
+     disk_revolve,
+     h_revolve,
      multistage,
-    #  twolevel_binomial,
-    #  mixed,
+     twolevel_binomial,
+     mixed,
      ]
      )
 @pytest.mark.parametrize("n, S", [


### PR DESCRIPTION
This PR aimed to Split de Copy(n, from_storage, to_storage, delete) action in:
Copy(n, from_storage, to_storage) and Move(n, from_storage, to_storage).
Additionally, StorageType.TAPE was renamed to StorageType.WORK, and set the default argument for storage in `SingleStorageSchedule`  as `StorageType.WORK`.