### PR TITLE
Change the python version requirement.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "checkpoint_schedules"
-version = "1.0.0"
+version = "1.0.2"
 authors = [
   { name="Daiane I. Dolci ", email="d.dolci@eimperial.ic.ac.uk" },
   { name="James R. Maddison", email="j.r.maddison@ed.ac.uk" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 description = "Schedules for incremental checkpointing of adjoint simulations."
 readme = "README.md"
 license = {text = "LGPL-3.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
Firedrake users are reporting issues related to the checkpoint_schedules python version requirement. This PR aims to update the python version requirement to agree with firedrake. If approved, I will update the pypi wheels.